### PR TITLE
Node Version Update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        version: [1.2.2, 1.9.0, 1.9.1, 1.9.2, 1.9.3, 1.9.4, 1.9.5, 1.9.6, 1.9.7, 1.9.8]
+        version: [1.2.2, 1.9.0, 1.9.1, 1.9.2, 1.9.4, 1.9.5, 1.9.6, 1.9.7, 1.9.8]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        version: [1.2.2, 1.9.0, 1.9.1, 1.9.2, 1.9.4, 1.9.5, 1.9.6, 1.9.7, 1.9.8]
+        version: [1.2.2, 1.9.0, 1.9.1, 1.9.2, 1.9.5, 1.9.6, 1.9.7, 1.9.8]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        version: [1.2.2]
+        version: [1.2.2, 1.9.0, 1.9.1, 1.9.2, 1.9.3, 1.9.4, 1.9.5, 1.9.6, 1.9.7, 1.9.8]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup gh
         uses: ./
@@ -40,7 +40,7 @@ jobs:
         version: [1.3.0]
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup gh
       uses: ./

--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
 # :gear: `setup-fianu`
 
 ## About
-This action can be run on `ubuntu-latest`, `windows-latest`, and `macos-latest` GitHub Actions runners, and will install and expose a specified version of the `fianu` CLI on the runner environment.
+
+The `setup-fianu` action facilitates the installation and exposure of a specified version of the `fianu` CLI on GitHub
+Actions runners. It is compatible with `ubuntu-latest`, `windows-latest`, and `macos-latest` runners.
 
 ## Usage
 
-Setup the `gh` CLI:
+To set up the `fianu` CLI, include the following step in your workflow:
 
 ```yaml
 steps:
-- uses: fianulabs/actions@main
+  - uses: fianulabs/actions@main
 ```
 
-A specific version of the `fianu` CLI can be installed:
+You can also specify a particular version of the fianu CLI to install:
 
 ```yaml
 steps:
-- uses: fianulabs/actions@main
-  with:
-    version: ${{ secrets.FIANU_VERSION }}
+  - uses: fianulabs/actions@main
+    with:
+      version: ${{ secrets.FIANU_VERSION }}
 ```
 
 ## Inputs
-The actions supports the following inputs:
 
-- `version`: The version of `fianu` to install, defaulting to `latest`
-
-## License
-[MIT](LICENSE).
+| Name      | Description                        | Default  |
+|-----------|------------------------------------|----------|
+| `version` | The version of `fianu` to install. | `latest` |

--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,10 @@
 name: setup-fianu
-description: Setup Fianu CLI, on GitHub Actions runners
+description: Sets up Fianu CLI on GitHub Actions runners
 inputs:
   version:
     description: Version of Fianu CLI to install
     required: false
-    default: 1.0.1
+    default: 1.9.8
 runs:
   using: node20
   main: dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -6,5 +6,5 @@ inputs:
     required: false
     default: 1.0.1
 runs:
-  using: node12
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
Updated node version from `node12` to `node20` per GitHub's [recommendation](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)