### PR TITLE
Feature/add windows init tests

### DIFF
--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feature/public-enterprise-secure-agent
   pull_request:
 
 defaults:

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -41,7 +41,7 @@ jobs:
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
           # Capture only stdout from the command
-          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path 'file:///\a\actions\actions\fianu_root_certs'
+          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path "D:\a\actions\actions\fianu_root_certs"
           
           # Write to GitHub summary (optional)
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n### Fianu Output`n"

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -33,6 +33,12 @@ jobs:
         with:
           version: ${{ matrix.version }}
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          # pin to a version that includes TUF support
+          cosign-release: 'v2.5.0'
+
       - name: Test CLI Windows
         shell: pwsh
         env:
@@ -41,7 +47,11 @@ jobs:
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
           # Capture only stdout from the command
-          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path "file:///D:/.sigstore"
+          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path "file:///D:/a/actions/actions/fianu_root_certs"
+          
+          cosign initialize `
+            --root 'D:\a\actions\actions\fianu_root_certs\root.json' `
+            --mirror 'file:///D:/a/actions/actions/fianu_root_certs/'
           
           # Write to GitHub summary (optional)
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n### Fianu Output`n"

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -49,4 +49,4 @@ jobs:
           # Write directory listing to GitHub summary
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### Directory Listing`n``````"
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $dirList.Trim()
-          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n````
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n````"

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -44,4 +44,5 @@ jobs:
           fianu root init
           
           # List current directory recursively
-          $dirList = Get-ChildItem -Recurse | Select-Object FullName | Out-String
+          $sigstorePath = Join-Path $env:USERPROFILE '.sigstore'
+          Get-ChildItem -Path $sigstorePath -Recurse -Force

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -41,7 +41,7 @@ jobs:
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
           # Capture only stdout from the command
-          .\fianu.exe root init --root-path D:\a\actions\actions\fianu_root_certs\root.json --mirror-path D:\a\actions\actions\fianu_root_certs
+          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path 'file:///D:\a\actions\actions\fianu_root_certs'
           
           # Write to GitHub summary (optional)
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n### Fianu Output`n"

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -41,7 +41,7 @@ jobs:
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
           # Capture only stdout from the command
-          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path "D:\a\actions\actions\fianu_root_certs"
+          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path "${{ github.workspace }}\fianu_root_certs"
           
           # Write to GitHub summary (optional)
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n### Fianu Output`n"

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -45,4 +45,4 @@ jobs:
           
           # List current directory recursively
           $sigstorePath = Join-Path $env:USERPROFILE '.sigstore'
-          Get-ChildItem -Path $sigstorePath -Recurse -Force
+          Get-ChildItem -Path $sigstorePath -Recurse -Force -ErrorAction SilentlyContinue

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -35,6 +35,11 @@ jobs:
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
           fianu root init --debug
+          # List files in current directory
+          Get-ChildItem -Name | Out-File -FilePath ls_output.txt -Encoding utf8
+          # Append output to GitHub summary
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### Directory Listing after fianu root init`n"
+          Get-Content ls_output.txt | ForEach-Object { Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $_ }
           uname -s | tr '[:upper:]' '[:lower:]'
 
   test_linux:

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -41,7 +41,7 @@ jobs:
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
           # Capture only stdout from the command
-          $fianuOutput = & .\fianu.exe root init --debug 2>&1
+          $fianuOutput = & fianu root init --debug 2>&1
           
           # Write to GitHub summary (optional)
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n### Fianu Output`n"

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -41,7 +41,7 @@ jobs:
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
           # Capture only stdout from the command
-          .\fianu.exe root init --root-path D:\a\actions\actions\fianu_root_certs\root.json --mirror-path file://D:\a\actions\actions\fianu_root_certs
+          .\fianu.exe root init --root-path D:\a\actions\actions\fianu_root_certs\root.json --mirror-path file:///D:\a\actions\actions\fianu_root_certs
           
           # Write to GitHub summary (optional)
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n### Fianu Output`n"

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -41,7 +41,7 @@ jobs:
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
           # Capture only stdout from the command
-          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path "file://${{ github.workspace }}\fianu_root_certs"
+          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path "file:///D:/a/actions/actions/fianu_root_certs"
           
           # Write to GitHub summary (optional)
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n### Fianu Output`n"

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -41,7 +41,7 @@ jobs:
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
           # Capture only stdout from the command
-          .\fianu.exe root init
+          .\fianu.exe root init --root-path D:\a\actions\actions\fianu_root_certs\root.json --mirror-path file://D:\a\actions\actions\fianu_root_certs
           
           # Write to GitHub summary (optional)
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n### Fianu Output`n"

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest-large, macos-13, macos-14]
-        version: [1.9.39]
+        version: [1.9.39, 1.9.40-1-beta]
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -47,9 +47,9 @@ jobs:
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
           # Capture only stdout from the command
-          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path "file:///C:\\a\\actions\\actions\\fianu_root_certs"
+          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path "file://C:\a\actions\actions\fianu_root_certs"
           
-          cosign initialize
+          cosign initialize  --root 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror 'file://D:\a\actions\actions\fianu_root_certs'
           
           # Write to GitHub summary (optional)
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n### Fianu Output`n"

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -34,13 +34,14 @@ jobs:
           FIANU_CLIENT_SECRET: ${{ secrets.FIANU_CLIENT_SECRET }}
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
-          fianu root init --debug
-          # List files in current directory
-          Get-ChildItem -Name | Out-File -FilePath ls_output.txt -Encoding utf8
-          # Append output to GitHub summary
-          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### Directory Listing after fianu root init`n"
-          Get-Content ls_output.txt | ForEach-Object { Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $_ }
-          uname -s | tr '[:upper:]' '[:lower:]'
+          $fianuOutput = fianu root init --debug 2>&1
+          $dirList = Get-ChildItem -Recurse | Select-Object FullName | Out-String
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### fianu root init --debug Output`n``````"
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $fianuOutput.Trim()
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "``````"
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### Directory Listing`n``````"
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $dirList.Trim()
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "``````"
 
   test_linux:
     name: Test

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest ]
-        version: [ 1.9.40-1-beta ]
+        version: [ 1.9.39-1-beta ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,32 +44,3 @@ jobs:
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### Directory Listing`n``````"
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $dirList.Trim()
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n``````"
-
-  test_linux:
-    name: Test
-    runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, macos-latest-large, macos-13, macos-14 ]
-        version: [ 1.9.40-1-beta ]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup gh
-        uses: ./
-        with:
-          version: ${{ matrix.version }}
-
-      - name: Test CLI Linux
-        shell: bash
-        env:
-          FIANU_CLIENT_ID: ${{ secrets.FIANU_CLIENT_ID }}
-          FIANU_CLIENT_SECRET: ${{ secrets.FIANU_CLIENT_SECRET }}
-          FIANU_HOST: ${{ secrets.FIANU_HOST }}
-        run: |-
-          uname -s | tr '[:upper:]' '[:lower:]'
-          fianu root init

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -3,8 +3,8 @@ name: Tests
 on:
   push:
     branches:
-    - main
-    - feature/add-windows-init-tests
+      - main
+      - feature/add-windows-init-tests
   pull_request:
 
 defaults:
@@ -17,22 +17,35 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest-large, macos-13, macos-14]
-        version: [1.9.40-1-beta]
+        os: [ ubuntu-latest, windows-latest, macos-latest-large, macos-13, macos-14 ]
+        version: [ 1.9.40-1-beta ]
+
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Setup gh
-      uses: ./
-      with:
-        version: ${{ matrix.version }}
+      - name: Setup gh
+        uses: ./
+        with:
+          version: ${{ matrix.version }}
 
-    - name: Test CLI
-      env:
-        FIANU_CLIENT_ID: ${{ secrets.FIANU_CLIENT_ID }}
-        FIANU_CLIENT_SECRET: ${{ secrets.FIANU_CLIENT_SECRET }}
-        FIANU_HOST: ${{ secrets.FIANU_HOST }}
-      run: |-
-        uname -s | tr '[:upper:]' '[:lower:]'
-        fianu root init
+      - name: Test CLI
+        if: startsWith(runner.os, 'Windows')
+        shell: pwsh
+        env:
+          FIANU_CLIENT_ID: ${{ secrets.FIANU_CLIENT_ID }}
+          FIANU_CLIENT_SECRET: ${{ secrets.FIANU_CLIENT_SECRET }}
+          FIANU_HOST: ${{ secrets.FIANU_HOST }}
+        run: |-
+          uname -s | tr '[:upper:]' '[:lower:]'
+          fianu root init
+
+      - name: Test CLI
+        if: !startsWith(runner.os, 'Windows')
+        env:
+          FIANU_CLIENT_ID: ${{ secrets.FIANU_CLIENT_ID }}
+          FIANU_CLIENT_SECRET: ${{ secrets.FIANU_CLIENT_SECRET }}
+          FIANU_HOST: ${{ secrets.FIANU_HOST }}
+        run: |-
+          uname -s | tr '[:upper:]' '[:lower:]'
+          fianu root init

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Test Root Init
 
 on:
   push:

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -7,19 +7,46 @@ on:
       - feature/add-windows-init-tests
   pull_request:
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
-  test:
-    name: Test
+  test_windows:
+    defaults:
+      run:
+        shell: pwsh
+    name: Test Windows
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest-large, macos-13, macos-14 ]
+        os: [ windows-latest ]
         version: [ 1.9.40-1-beta ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
+      - name: Setup gh
+        uses: ./
+        with:
+          version: ${{ matrix.version }}
+
+      - name: Test CLI Windows
+        shell: pwsh
+        env:
+          FIANU_CLIENT_ID: ${{ secrets.FIANU_CLIENT_ID }}
+          FIANU_CLIENT_SECRET: ${{ secrets.FIANU_CLIENT_SECRET }}
+          FIANU_HOST: ${{ secrets.FIANU_HOST }}
+        run: |-
+          uname -s | tr '[:upper:]' '[:lower:]'
+          fianu root init
+
+  test_linux:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest-large, macos-13, macos-14 ]
+        version: [ 1.9.40-1-beta ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,18 +57,7 @@ jobs:
           version: ${{ matrix.version }}
 
       - name: Test CLI Linux
-        if: startsWith(runner.os, 'Windows')
-        shell: pwsh
-        env:
-          FIANU_CLIENT_ID: ${{ secrets.FIANU_CLIENT_ID }}
-          FIANU_CLIENT_SECRET: ${{ secrets.FIANU_CLIENT_SECRET }}
-          FIANU_HOST: ${{ secrets.FIANU_HOST }}
-        run: |-
-          uname -s | tr '[:upper:]' '[:lower:]'
-          fianu root init
-
-      - name: Test CLI Windows
-        if: !startsWith(runner.os, 'Windows')
+        shell: bash
         env:
           FIANU_CLIENT_ID: ${{ secrets.FIANU_CLIENT_ID }}
           FIANU_CLIENT_SECRET: ${{ secrets.FIANU_CLIENT_SECRET }}

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -34,8 +34,8 @@ jobs:
           FIANU_CLIENT_SECRET: ${{ secrets.FIANU_CLIENT_SECRET }}
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
+          fianu root init --debug
           uname -s | tr '[:upper:]' '[:lower:]'
-          fianu root init
 
   test_linux:
     name: Test

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -49,9 +49,7 @@ jobs:
           # Capture only stdout from the command
           .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path "file:///D:/a/actions/actions/fianu_root_certs"
           
-          cosign initialize `
-            --root 'D:\a\actions\actions\fianu_root_certs\root.json' `
-            --mirror 'file:///D:/a/actions/actions/fianu_root_certs/'
+          cosign initialize
           
           # Write to GitHub summary (optional)
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n### Fianu Output`n"

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
 
-      - name: Test CLI
+      - name: Test CLI Linux
         if: startsWith(runner.os, 'Windows')
         shell: pwsh
         env:
@@ -40,7 +40,7 @@ jobs:
           uname -s | tr '[:upper:]' '[:lower:]'
           fianu root init
 
-      - name: Test CLI
+      - name: Test CLI Windows
         if: !startsWith(runner.os, 'Windows')
         env:
           FIANU_CLIENT_ID: ${{ secrets.FIANU_CLIENT_ID }}

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -41,7 +41,6 @@ jobs:
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
           # Capture only stdout from the command
-          fianu root init -d
           $fianuOutput = & .\fianu.exe root init --debug 2>&1
           
           # Write to GitHub summary (optional)

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -12,25 +12,6 @@ defaults:
     shell: bash
 
 jobs:
-  deptest:
-    name: Test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        version: [1.9.39]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup gh
-        uses: ./
-        with:
-          version: ${{ matrix.version }}
-
-      - name: Test CLI
-        run: |-
-          fianu
   test:
     name: Test
     runs-on: ${{ matrix.os }}
@@ -48,6 +29,10 @@ jobs:
         version: ${{ matrix.version }}
 
     - name: Test CLI
+      env:
+        FIANU_CLIENT_ID: ${{ secrets.FIANU_CLIENT_ID }}
+        FIANU_CLIENT_SECRET: ${{ secrets.FIANU_CLIENT_SECRET }}
+        FIANU_HOST: ${{ secrets.FIANU_HOST }}
       run: |-
         uname -s | tr '[:upper:]' '[:lower:]'
         fianu root init

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -41,7 +41,7 @@ jobs:
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
           # Capture only stdout from the command
-          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path "file:///D:/a/actions/actions/fianu_root_certs"
+          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path "file:///D:/.sigstore"
           
           # Write to GitHub summary (optional)
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n### Fianu Output`n"

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feature/add-windows-init-tests
   pull_request:
 
 permissions:

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -41,7 +41,7 @@ jobs:
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
           # Capture only stdout from the command
-          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\rootz.json' --mirror-path 'file:///D:\a\actions\actions\fianu_root_certs'
+          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path 'file:///\a\actions\actions\fianu_root_certs'
           
           # Write to GitHub summary (optional)
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n### Fianu Output`n"

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -47,7 +47,7 @@ jobs:
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
           # Capture only stdout from the command
-          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path "file:///C:/a/actions/actions/fianu_root_certs"
+          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path 'file:///a/actions/actions/fianu_root_certs'
           
           cosign initialize  --root 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror 'file:///a/actions/actions/fianu_root_certs'
           

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -47,7 +47,7 @@ jobs:
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
           # Capture only stdout from the command
-          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path "file:///D:/a/actions/actions/fianu_root_certs"
+          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path "file:///C:\\a\\actions\\actions\\fianu_root_certs"
           
           cosign initialize
           

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -44,5 +44,9 @@ jobs:
           fianu root init
           
           # List current directory recursively
-          $sigstorePath = Join-Path $env:USERPROFILE '.sigstore'
-          Get-ChildItem -Path $sigstorePath -Recurse -Force -ErrorAction SilentlyContinue
+          $dirList = Get-ChildItem -Recurse | Select-Object FullName | Out-String
+          
+          # Write directory listing to GitHub summary
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### Directory Listing`n``````"
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $dirList.Trim()
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n````

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -34,14 +34,25 @@ jobs:
           FIANU_CLIENT_SECRET: ${{ secrets.FIANU_CLIENT_SECRET }}
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
-          $fianuOutput = fianu root init --debug 2>&1
+          # Capture only stdout from the command
+          $fianuOutput = & { fianu root init --debug } 2>$null
+          
+          # List current directory recursively
           $dirList = Get-ChildItem -Recurse | Select-Object FullName | Out-String
-          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### fianu root init --debug Output`n``````"
-          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $fianuOutput.Trim()
-          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "``````"
+          
+          # Write fianu output to GitHub summary
+          if (-not [string]::IsNullOrWhiteSpace($fianuOutput)) {
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### fianu root init --debug Output`n``````"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $fianuOutput.Trim()
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n``````"
+          } else {
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### fianu root init --debug Output`n_No output was returned._"
+          }
+                  
+          # Write directory listing to GitHub summary
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### Directory Listing`n``````"
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $dirList.Trim()
-          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "``````"
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n``````"
 
   test_linux:
     name: Test

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest ]
-        version: [ 1.9.39-1-beta ]
+        version: [ 1.9.39-beta-1 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -41,7 +41,7 @@ jobs:
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
           # Capture only stdout from the command
-          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path "${{ github.workspace }}\fianu_root_certs"
+          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path "file://${{ github.workspace }}\fianu_root_certs"
           
           # Write to GitHub summary (optional)
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n### Fianu Output`n"

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -41,7 +41,7 @@ jobs:
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
           # Capture only stdout from the command
-          $fianuOutput = & fianu root init --debug 2>&1
+          .\fianu.exe root init
           
           # Write to GitHub summary (optional)
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n### Fianu Output`n"

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -35,19 +35,10 @@ jobs:
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
           # Capture only stdout from the command
-          $fianuOutput = & { fianu root init --debug } 2>$null
+          fianu root init
           
           # List current directory recursively
           $dirList = Get-ChildItem -Recurse | Select-Object FullName | Out-String
-          
-          # Write fianu output to GitHub summary
-          if (-not [string]::IsNullOrWhiteSpace($fianuOutput)) {
-            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### fianu root init --debug Output`n``````"
-            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $fianuOutput.Trim()
-            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n``````"
-          } else {
-            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### fianu root init --debug Output`n_No output was returned._"
-          }
                   
           # Write directory listing to GitHub summary
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### Directory Listing`n``````"

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -41,7 +41,7 @@ jobs:
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
           # Capture only stdout from the command
-          .\fianu.exe root init --root-path D:\a\actions\actions\fianu_root_certs\root.json --mirror-path file:///D:\a\actions\actions\fianu_root_certs
+          .\fianu.exe root init --root-path D:\a\actions\actions\fianu_root_certs\root.json --mirror-path D:\a\actions\actions\fianu_root_certs
           
           # Write to GitHub summary (optional)
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n### Fianu Output`n"

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -47,9 +47,9 @@ jobs:
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
           # Capture only stdout from the command
-          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path "file://C:\a\actions\actions\fianu_root_certs"
+          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path "file:///C:/a/actions/actions/fianu_root_certs"
           
-          cosign initialize  --root 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror 'file://D:\a\actions\actions\fianu_root_certs'
+          cosign initialize  --root 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror 'file:///a/actions/actions/fianu_root_certs'
           
           # Write to GitHub summary (optional)
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n### Fianu Output`n"

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
     - main
-      - feature/public-enterprise-secure-agent
+    - feature/add-windows-init-tests
   pull_request:
 
 defaults:
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        version: [1.2.2, 1.9.0, 1.9.1, 1.9.2, 1.9.5, 1.9.6, 1.9.7, 1.9.8, 1.9.35, 1.9.39]
+        version: [1.9.39]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest-large, macos-13, macos-14]
-        version: [1.3.0, 1.9.11, 1.9.35, 1.9.39]
+        version: [1.3.0, 1.9.11, 1.9.39]
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -50,4 +50,4 @@ jobs:
     - name: Test CLI
       run: |-
         uname -s | tr '[:upper:]' '[:lower:]'
-        fianu
+        fianu root init

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest-large, macos-13, macos-14]
-        version: [1.3.0, 1.9.11, 1.9.39]
+        version: [1.9.39]
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -41,7 +41,7 @@ jobs:
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
           # Capture only stdout from the command
-          fianu root init
+          fianu root init -d
           
           # List current directory recursively
           $dirList = Get-ChildItem -Recurse | Select-Object FullName | Out-String

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -42,11 +42,15 @@ jobs:
         run: |-
           # Capture only stdout from the command
           fianu root init -d
+          $fianuOutput = & .\fianu.exe root init --debug 2>&1
           
-          # List current directory recursively
+          # Write to GitHub summary (optional)
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n### Fianu Output`n"
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "``````"
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "$fianuOutput"
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "``````"
+          # Also write to console log
           $dirList = Get-ChildItem -Recurse | Select-Object FullName | Out-String
-          
-          # Write directory listing to GitHub summary
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### Directory Listing`n``````"
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $dirList.Trim()
-          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n````"
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n``````"

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -41,7 +41,7 @@ jobs:
           FIANU_HOST: ${{ secrets.FIANU_HOST }}
         run: |-
           # Capture only stdout from the command
-          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path 'file:///D:\a\actions\actions\fianu_root_certs'
+          .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\rootz.json' --mirror-path 'file:///D:\a\actions\actions\fianu_root_certs'
           
           # Write to GitHub summary (optional)
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n### Fianu Output`n"

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest-large, macos-13, macos-14]
-        version: [1.9.39, 1.9.40-1-beta]
+        version: [1.9.40-1-beta]
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest ]
-        version: [ 1.9.39-beta-1 ]
+        version: [ 1.9.39 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -48,6 +48,7 @@ jobs:
         run: |-
           # Capture only stdout from the command
           .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path 'file:///a/actions/actions/fianu_root_certs'
+          .\fianu.exe root init
                     
           # Write to GitHub summary (optional)
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n### Fianu Output`n"

--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -48,9 +48,7 @@ jobs:
         run: |-
           # Capture only stdout from the command
           .\fianu.exe root init --root-path 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror-path 'file:///a/actions/actions/fianu_root_certs'
-          
-          cosign initialize  --root 'D:\a\actions\actions\fianu_root_certs\root.json' --mirror 'file:///a/actions/actions/fianu_root_certs'
-          
+                    
           # Write to GitHub summary (optional)
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "`n### Fianu Output`n"
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "``````"

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feature/add-windows-init-tests
   pull_request:
 
 defaults:

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -1,9 +1,10 @@
-name: Tests
+name: Test CLI
 
 on:
   push:
     branches:
-    - main
+      - main
+      - feature/add-windows-init-tests
   pull_request:
 
 defaults:
@@ -16,8 +17,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        version: [1.2.2, 1.9.0, 1.9.1, 1.9.2, 1.9.5, 1.9.6, 1.9.7, 1.9.8, 1.9.35, 1.9.39, 1.9.40-1-beta]
+        os: [ ubuntu-latest ]
+        version: [ 1.2.2, 1.9.0, 1.9.1, 1.9.2, 1.9.5, 1.9.6, 1.9.7, 1.9.8, 1.9.35, 1.9.39, 1.9.40-1-beta ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,18 +36,30 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest-large, macos-13, macos-14]
-        version: [1.3.0, 1.9.11, 1.9.35, 1.9.39, 1.9.40-1-beta]
+        os: [ ubuntu-latest, windows-latest, macos-latest-large, macos-13, macos-14 ]
+        version: [ 1.3.0, 1.9.11, 1.9.35, 1.9.39, 1.9.40-1-beta ]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Setup gh
-      uses: ./
-      with:
-        version: ${{ matrix.version }}
+      - name: Setup gh
+        uses: ./
+        with:
+          version: ${{ matrix.version }}
 
-    - name: Test CLI
-      run: |-
-        uname -s | tr '[:upper:]' '[:lower:]'
-        fianu
+      - name: Test CLI
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: |-
+          uname -s | tr '[:upper:]' '[:lower:]'
+          fianu
+
+      - name: Test CLI Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: pwsh
+        env:
+          FIANU_CLIENT_ID: ${{ secrets.FIANU_CLIENT_ID }}
+          FIANU_CLIENT_SECRET: ${{ secrets.FIANU_CLIENT_SECRET }}
+          FIANU_HOST: ${{ secrets.FIANU_HOST }}
+        run: |-
+          uname -s | tr '[:upper:]' '[:lower:]'
+          fianu

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - main
-      - feature/public-enterprise-secure-agent
   pull_request:
 
 defaults:

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -12,12 +12,12 @@ defaults:
 
 jobs:
   deptest:
-    name: Test
+    name: DepTest
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]
-        version: [1.2.2, 1.9.0, 1.9.1, 1.9.2, 1.9.5, 1.9.6, 1.9.7, 1.9.8, 1.9.35, 1.9.39]
+        version: [1.2.2, 1.9.0, 1.9.1, 1.9.2, 1.9.5, 1.9.6, 1.9.7, 1.9.8, 1.9.35, 1.9.39, 1.9.40-1-beta]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest-large, macos-13, macos-14]
-        version: [1.3.0, 1.9.11, 1.9.35, 1.9.39]
+        version: [1.3.0, 1.9.11, 1.9.35, 1.9.39, 1.9.40-1-beta]
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
This pull request introduces updates to GitHub Actions workflows to enhance testing coverage and organization. Key changes include the addition of a new workflow for Windows-specific CLI tests, updates to existing workflows to support additional test cases, and minor naming adjustments for clarity.

### Additions to GitHub Actions workflows:

* Added a new workflow file, `.github/workflows/test-cli-root-init.yml`, to test Windows-specific CLI initialization. This includes a dedicated `test_windows` job with environment setup, dependency installation, and CLI testing steps.

### Updates to existing workflows:

* Updated `.github/workflows/test-cli.yml`:
  - Renamed the workflow from `Tests` to `Test CLI` for better clarity.
  - Renamed the `deptest` job to `DepTest` and expanded the matrix of versions tested to include `1.9.39` and `1.9.40-1-beta`. [[1]](diffhunk://#diff-8b9d3e20095e62d71b26794937d5b34d27f07ff88116db495f2a0a398757e94eL16-R21) [[2]](diffhunk://#diff-8b9d3e20095e62d71b26794937d5b34d27f07ff88116db495f2a0a398757e94eL40-R40)
  - Added conditional steps for Windows-specific CLI tests, separating them from non-Windows tests.

### Removal of outdated branches:

* Removed the `feature/public-enterprise-secure-agent` branch from the `push` trigger in `.github/workflows/test-agent.yml` and `.github/workflows/test-cli.yml`. [[1]](diffhunk://#diff-3c1e3ffee56642b2a90c941707a5ae7f973bda43f91dc3788e8873e95cdec381L7) [[2]](diffhunk://#diff-8b9d3e20095e62d71b26794937d5b34d27f07ff88116db495f2a0a398757e94eL1-R7)

These changes improve test coverage across different operating systems and streamline workflow configurations.