### PR TITLE
1.9.67

### DIFF
--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        version: [ 1.2.2, 1.9.0, 1.9.1, 1.9.2, 1.9.5, 1.9.6, 1.9.7, 1.9.8, 1.9.35, 1.9.39, 1.9.40-1-beta, 1.9.55, 1.9.56, 1.9.63, 1.9.66 ]
+        version: [ 1.2.2, 1.9.0, 1.9.1, 1.9.2, 1.9.5, 1.9.6, 1.9.7, 1.9.8, 1.9.35, 1.9.39, 1.9.40-1-beta, 1.9.55, 1.9.56, 1.9.63, 1.9.66, 1.9.67 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest-large, macos-13, macos-14 ]
-        version: [ 1.3.0, 1.9.11, 1.9.35, 1.9.39, 1.9.40-1-beta, 1.9.55, 1.9.56, 1.9.66 ]
+        version: [ 1.3.0, 1.9.11, 1.9.35, 1.9.39, 1.9.40-1-beta, 1.9.55, 1.9.56, 1.9.66, 1.9.67 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: Version of Fianu CLI to install
     required: false
-    default: 1.9.66
+    default: 1.9.67
 runs:
   using: node20
   main: dist/index.js


### PR DESCRIPTION
This pull request updates the supported and default versions of the Fianu CLI in both the GitHub Actions workflow and the action metadata. The main goal is to add support for version `1.9.67` and set it as the new default version.

**Version support and configuration updates:**

* Added `1.9.67` to the list of Fianu CLI versions tested in the Ubuntu workflow matrix in `.github/workflows/test-cli.yml`.
* Added `1.9.67` to the list of Fianu CLI versions tested across multiple OSes in `.github/workflows/test-cli.yml`.
* Updated the default Fianu CLI version to `1.9.67` in `action.yml`.