### PR TITLE
Bump CLI Version

### DIFF
--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -30,6 +30,7 @@ jobs:
           - 1.9.58
           - 1.9.63
           - 1.9.66
+          - 1.9.73
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        version: [ 1.2.2, 1.9.0, 1.9.1, 1.9.2, 1.9.5, 1.9.6, 1.9.7, 1.9.8, 1.9.35, 1.9.39, 1.9.40-1-beta, 1.9.55, 1.9.56, 1.9.63, 1.9.66, 1.9.67 ]
+        version: [ 1.2.2, 1.9.0, 1.9.1, 1.9.2, 1.9.5, 1.9.6, 1.9.7, 1.9.8, 1.9.35, 1.9.39, 1.9.40-1-beta, 1.9.55, 1.9.56, 1.9.63, 1.9.66, 1.9.67, 1.9.73 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest-large, macos-13, macos-14 ]
-        version: [ 1.3.0, 1.9.11, 1.9.35, 1.9.39, 1.9.40-1-beta, 1.9.55, 1.9.56, 1.9.66, 1.9.67 ]
+        version: [ 1.3.0, 1.9.11, 1.9.35, 1.9.39, 1.9.40-1-beta, 1.9.55, 1.9.56, 1.9.66, 1.9.67, 1.9.73 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: Version of Fianu CLI to install
     required: false
-    default: 1.9.67
+    default: 1.9.73
 runs:
   using: node20
   main: dist/index.js


### PR DESCRIPTION
This pull request updates the supported versions of the Fianu CLI across GitHub Actions workflows and sets the default version to `1.9.73`. The main goal is to ensure CI tests and the action itself use the latest available CLI version.

**Workflow and configuration updates:**

* Updated the default Fianu CLI version to `1.9.73` in `action.yml` so new runs use the latest by default.

* Added version `1.9.73` to the test matrix in the following workflow files, ensuring CI coverage for the latest release:
  - `.github/workflows/test-cli-root-init.yml`
  - `.github/workflows/test-cli.yml` [[1]](diffhunk://#diff-8b9d3e20095e62d71b26794937d5b34d27f07ff88116db495f2a0a398757e94eL20-R20) [[2]](diffhunk://#diff-8b9d3e20095e62d71b26794937d5b34d27f07ff88116db495f2a0a398757e94eL39-R39)