### PR TITLE
feature/add-login-action-with-federated-support

### DIFF
--- a/.github/workflows/test-cli-root-init.yml
+++ b/.github/workflows/test-cli-root-init.yml
@@ -31,6 +31,7 @@ jobs:
           - 1.9.63
           - 1.9.66
           - 1.9.73
+          - 1.9.75
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        version: [ 1.2.2, 1.9.0, 1.9.1, 1.9.2, 1.9.5, 1.9.6, 1.9.7, 1.9.8, 1.9.35, 1.9.39, 1.9.40-1-beta, 1.9.55, 1.9.56, 1.9.63, 1.9.66, 1.9.67, 1.9.73 ]
+        version: [ 1.2.2, 1.9.0, 1.9.1, 1.9.2, 1.9.5, 1.9.6, 1.9.7, 1.9.8, 1.9.35, 1.9.39, 1.9.40-1-beta, 1.9.55, 1.9.56, 1.9.63, 1.9.66, 1.9.67, 1.9.73, 1.9.75 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest-large, macos-13, macos-14 ]
-        version: [ 1.3.0, 1.9.11, 1.9.35, 1.9.39, 1.9.40-1-beta, 1.9.55, 1.9.56, 1.9.66, 1.9.67, 1.9.73 ]
+        version: [ 1.3.0, 1.9.11, 1.9.35, 1.9.39, 1.9.40-1-beta, 1.9.55, 1.9.56, 1.9.66, 1.9.67, 1.9.73, 1.9.75 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: Version of Fianu CLI to install
     required: false
-    default: 1.9.73
+    default: 1.9.75
 runs:
   using: node20
   main: dist/index.js

--- a/gate/action.yaml
+++ b/gate/action.yaml
@@ -32,7 +32,7 @@ inputs:
   fianu_version:
     description: 'The version of the Fianu CLI to use'
     required: false
-    default: 'latest'
+    default: '1.9.75'
   fianu_artifact:
     description: 'The artifact name and version to be used in the gate check'
     required: false

--- a/login/action.yaml
+++ b/login/action.yaml
@@ -1,0 +1,58 @@
+name: 'Fianu Login Action'
+author: 'Fianu Labs'
+description: |
+  Authenticates to Fianu from a GitHub Actions workflow using GitHub's OIDC
+  token (Workload Identity Federation) — no static client secrets required.
+  The action installs the Fianu CLI, exchanges the GitHub OIDC token for a
+  Fianu access token, and persists it to `~/.fianu/fianu.conf.v1`. Subsequent
+  steps (other `fianu` commands, or the `fianulabs/fianu` Terraform provider)
+  then authenticate off that file with no further credentials.
+
+  The calling job MUST grant `permissions: id-token: write` so GitHub will mint
+  the OIDC token.
+branding:
+  icon: 'log-in'
+  color: 'yellow'
+inputs:
+  fianu_host:
+    description: 'The Fianu host URL (usually stored in secrets)'
+    required: true
+  fianu_organization:
+    description: 'Fianu organization slug for the WIF exchange (defaults to the repository owner)'
+    required: false
+  fianu_audience:
+    description: 'OIDC audience for the GitHub token request (defaults to the server URL + owner)'
+    required: false
+  fianu_client_id:
+    description: 'Optional Fianu client ID to scope the federated exchange'
+    required: false
+  fianu_version:
+    description: 'The version of the Fianu CLI to use'
+    required: false
+    default: '1.9.75'
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Fianu
+      id: setup_fianu
+      uses: fianulabs/actions@main
+      with:
+        version: ${{ inputs.fianu_version }}
+
+    - name: Fianu Federated Login
+      id: fianu_login
+      shell: bash
+      env:
+        FIANU_HOST: ${{ inputs.fianu_host }}
+        FIANU_ORGANIZATION: ${{ inputs.fianu_organization }}
+        FIANU_OIDC_AUDIENCE: ${{ inputs.fianu_audience }}
+        FIANU_CLIENT_ID: ${{ inputs.fianu_client_id }}
+      run: |
+        echo "::group::fianu auth login (federated)"
+        # The CLI auto-fetches the GitHub OIDC token from the
+        # ACTIONS_ID_TOKEN_REQUEST_* env vars (present when the job has
+        # `permissions: id-token: write`), exchanges it via WIF, and writes
+        # the resulting Fianu token to ~/.fianu/fianu.conf.v1.
+        fianu auth login
+        echo "::endgroup::"


### PR DESCRIPTION
This pull request updates the workflows and action configuration files to add support for Fianu CLI version 1.9.75 and introduces a new login action for authenticating to Fianu using GitHub's OIDC tokens. The key changes are grouped below by theme.

**Fianu CLI version updates:**

* Added version `1.9.75` to the test matrices in `.github/workflows/test-cli.yml` and `.github/workflows/test-cli-root-init.yml` to ensure this version is tested across supported platforms. [[1]](diffhunk://#diff-8b9d3e20095e62d71b26794937d5b34d27f07ff88116db495f2a0a398757e94eL23-R23) [[2]](diffhunk://#diff-8b9d3e20095e62d71b26794937d5b34d27f07ff88116db495f2a0a398757e94eL42-R42) [[3]](diffhunk://#diff-c6a208866a816e8401ddc9f4606c88d6a6ee576b75eb8bf64bf13053edd56807R34)
* Updated the default Fianu CLI version to `1.9.75` in `action.yml` and set it as the default in `gate/action.yaml` instead of `'latest'`. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L7-R7) [[2]](diffhunk://#diff-dc580f9f01932075e74bfe5b4af897405012b9f5c6e04048f8c7b5d0713418b5L35-R35)

**New authentication action:**

* Added a new composite action in `login/action.yaml` that enables authentication to Fianu from GitHub Actions using GitHub's OIDC token (Workload Identity Federation), removing the need for static client secrets. This action installs the Fianu CLI, exchanges the OIDC token for a Fianu access token, and persists it for subsequent steps.